### PR TITLE
Fix Task example in ch08.md

### DIFF
--- a/ch08.md
+++ b/ch08.md
@@ -502,7 +502,7 @@ const readFile = filename => new Task((reject, result) => {
   fs.readFile(filename, (err, data) => (err ? reject(err) : result(data)));
 });
 
-readFile('metamorphosis').map(split('\n')).map(head);
+readFile('metamorphosis').map(toString).map(split('\n')).map(head);
 // Task('One morning, as Gregor Samsa was waking up from anxious dreams, he discovered that
 // in bed he had been changed into a monstrous verminous bug.')
 


### PR DESCRIPTION
Add `.map(toString)` in the Task example before `.map(split('\n'))` to 
prevent error caused by splitting a Node Buffer.